### PR TITLE
Restructured structs to save on memory

### DIFF
--- a/assembler/assembler.go
+++ b/assembler/assembler.go
@@ -26,21 +26,21 @@ var InterCtx *intergo.InterContext
 // Can be a label, an instruction, an argument or a literal. All directives are
 // resolved in the tokenizer stage.
 type Token struct {
-	Line  int
 	File  *string
-	Type  int
 	Value []byte
+	Line  int
+	Type  int
 }
 
 // This token is specifically an instruction. An array of these is passed to the
 // debugger.
 type DebuggerToken struct {
-	Line        int
-	File        *string
 	Instruction string
+	Label       string
+	File        *string
 	Args        []string
 	Address     uint64
-	Label       string
+	Line        int
 }
 
 // This kind of token can be only instructions and literals (only instructions
@@ -48,22 +48,22 @@ type DebuggerToken struct {
 // field is reserved for architecture-specific use (example: storing information
 // regarding the addressing mode in 6502).
 type ResolvedToken struct {
-	Line     int
 	File     *string
-	Type     int
-	Address  uint64
-	Value    []byte
 	Args     []uint64
+	Value    []byte
+	Address  uint64
+	Line     int
+	Type     int
 	Reserved uintptr
 }
 
 // For intermediate reasons.
 type Instruction struct {
-	Line     int
-	File     *string
 	Mnemonic string
+	File     *string
 	Args     []string
 	Size     uint64
+	Line     int
 	Reserved uintptr
 }
 

--- a/debugger.go
+++ b/debugger.go
@@ -19,10 +19,10 @@ import (
 type Breakpoint struct {
 	// nil if no file.
 	File *string
-	// This is only valid if File is non-nil, of course.
-	Line int
 	// Empty if no label
 	Label string
+	// This is only valid if File is non-nil, of course.
+	Line int
 	// This one always exists.
 	Address uint64
 }
@@ -390,7 +390,6 @@ func parseBreakpoint(arg string, sym []assembler.DebuggerToken) (Breakpoint, err
 					}
 				}
 			}
-
 		}
 	}
 


### PR DESCRIPTION
In Go, structs are stored in memory "as-is", that is, in the order that they are written. Due to padding, this ends up leaving a bit of memory unused. It is possible (and pretty easy) to re-organize structs so as to optimize them for memory usage.

This is a pretty small PR that just optimizes some of the structs. It may be undesirable for aesthetic reasons, but in my opinion it's a pretty painless improvement.

Here is the data, if you're interested (obtained via the go lsp):

| Struct  | Old size (bytes | New size (bytes) |
| --- | --- | --- |
| Token | 32  | 16  |
| DebuggerToken | 72 | 48  |
| ResolvedToken | 64  | 40  |
| Instruction | 40  | 32  |
| Breakpoint | 24 | 16 |